### PR TITLE
battlefield protocol sometimes missing fields and result in unpacking too many values

### DIFF
--- a/opengsq/protocols/battlefield.py
+++ b/opengsq/protocols/battlefield.py
@@ -39,11 +39,11 @@ class Battlefield(ProtocolBase):
         info["teams"] = [float(data.pop(0)) for _ in range(num_teams)]
         info["target_score"] = int(data.pop(0))
         info["status"] = data.pop(0)
-        info["ranked"] = data.pop(0) == "true"
-        info["punk_buster"] = data.pop(0) == "true"
-        info["password"] = data.pop(0) == "true"
-        info["uptime"] = int(data.pop(0))
-        info["round_time"] = int(data.pop(0))
+        info["ranked"] = (data.pop(0) == "true") if data else "false"
+        info["punk_buster"] = (data.pop(0) == "true") if data else "false"
+        info["password"] = (data.pop(0) == "true") if data else "false"
+        info["uptime"] = int(data.pop(0)) if data else 0
+        info["round_time"] = int(data.pop(0)) if data else 0
 
         try:
             if data[0] == "BC2":


### PR DESCRIPTION
Hi,

thank you very much for your library. I use it on a small project and found an error: some bfbc2 servers do not have enough values to unpack and therefore your library crashes. The following fix does work work fine for me. Feel free to suggest changes if necessary.

Thanks for this great library! Helping me a lot :)