### PR TITLE
Fix for Satisfactory

### DIFF
--- a/opengsq/responses/satisfactory/status.py
+++ b/opengsq/responses/satisfactory/status.py
@@ -10,8 +10,11 @@ class Status:
     state: int
     """The state."""
 
-    version: int
-    """The version."""
+    num_players: int
+    """The number of players currently connected to the server."""
 
-    beacon_port: int
-    """The beacon port."""
+    max_players: int
+    """The maximum number of players that can connect to the server."""
+ 
+    name: str
+    """The name of the server."""


### PR DESCRIPTION
Fixes Satisfactory's Status class. It wasn't returning the server name, current number of players, or maximum number of players. It was returning the server state (good), version (unused) and beacon (unused).